### PR TITLE
Projects - flash calls Pairing for Reset to BLE mode UI

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="gamepad">Gamepad</string>
     <string name="connectNew">Pair a new micro:bit</string>
     <string name="connect_tip_title">How to pair your micro:bit</string>
+    <string name="connect_tip_title_resetToBLE">Reset to Bluetooth mode</string>
     <string name="step_connect_tip_text_step_three">Step 3</string>
     <string name="step_connect_tip_text_step_four_text">When you see the success message, \npress RESET and you\'re done!</string>
     <string name="connect_tip_text_step">Step 1</string>


### PR DESCRIPTION
Projects calls Pairing....

When the app bar connect icon is tapped. This is not new, and is simply a shortcut.

During a flash, when there is no current micro:bit. This route used to open the main pairing screen, but now launches the pairing process, continues flashing if pairing succeeded, and returns to Projects or MakeCode on failure. 

During a flash, to prompt for BLE mode. This is a new. The Next button continues the flash process and Cancel aborts, including returning to MakeCode as required.
