### PR TITLE
Fix zip path traversal error and update to v3.0.6 (56)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,8 +15,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="55"
-    android:versionName="3.0.5">
+    android:versionCode="56"
+    android:versionName="3.0.6">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>

--- a/app/src/main/java/com/samsung/microbit/utils/ProjectsHelper.java
+++ b/app/src/main/java/com/samsung/microbit/utils/ProjectsHelper.java
@@ -207,6 +207,7 @@ public class ProjectsHelper {
 
                 File f = projectFile(context, ze.getName());
                 if (!f.getCanonicalPath().startsWith(projectRoot(context).getCanonicalPath())) {
+                    // Skip file with unexpected directory
                     continue;
                 }
 

--- a/app/src/main/java/com/samsung/microbit/utils/ProjectsHelper.java
+++ b/app/src/main/java/com/samsung/microbit/utils/ProjectsHelper.java
@@ -205,13 +205,17 @@ public class ProjectsHelper {
             while((ze = zin.getNextEntry()) != null) {
                 Log.v("MicroBit", "Unzipping " + ze.getName());
 
+                File f = projectFile(context, ze.getName());
+                if (!f.getCanonicalPath().startsWith(projectRoot(context).getCanonicalPath())) {
+                    throw new SecurityException();
+                }
+
                 if (ze.isDirectory()) {
-                    File f = projectFile( context, ze.getName());
                     if ( !f.isDirectory()) {
                         f.mkdirs();
                     }
                 } else {
-                    FileOutputStream fout = new FileOutputStream( projectFile( context, ze.getName()));
+                    FileOutputStream fout = new FileOutputStream(f);
                     BufferedOutputStream bufout = new BufferedOutputStream(fout);
                     byte[] buffer = new byte[1024];
                     int read = 0;

--- a/app/src/main/java/com/samsung/microbit/utils/ProjectsHelper.java
+++ b/app/src/main/java/com/samsung/microbit/utils/ProjectsHelper.java
@@ -207,7 +207,7 @@ public class ProjectsHelper {
 
                 File f = projectFile(context, ze.getName());
                 if (!f.getCanonicalPath().startsWith(projectRoot(context).getCanonicalPath())) {
-                    throw new SecurityException();
+                    continue;
                 }
 
                 if (ze.isDirectory()) {


### PR DESCRIPTION
Error found in pre-launch report. 

"Your app contains an unsafe unzipping pattern that may lead to a Path Traversal vulnerability. Please see [this Google Help Center article](https://support.google.com/faqs/answer/9294009) to learn how to fix the issue.

com.samsung.microbit.utils.ProjectsHelper.installSamples"

cc: @jaustin @microbit-matt-hillsdon 