### PR TITLE
Device name can be null in some circumstances

### DIFF
--- a/app/src/main/java/com/samsung/microbit/utils/BLEPair.java
+++ b/app/src/main/java/com/samsung/microbit/utils/BLEPair.java
@@ -643,7 +643,7 @@ public class BLEPair implements BluetoothAdapter.LeScanCallback {
                 final int state = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.ERROR);
                 final int prevState = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.ERROR);
                 logi("pairReceiver -" + " name = " + name + " addr = " + addr + " state = " + state + " prevState = " + prevState);
-                if (name.isEmpty() || addr.isEmpty()) {
+                if (name == null || name.isEmpty() || addr.isEmpty()) {
                     return;
                 }
                 // Check the changed device is the one we are trying to pair


### PR DESCRIPTION
We didn't reproduce this but based on this crash and similar guards elsewhere in the code this seems a reasonable fix.

https://play.google.com/console/u/0/developers/4695663865375895527/app/4975736116501095047/vitals/crashes/e9abff6694fe9443f6d3423bb5f7b44b/details?days=28&versionCode=57&isUserPerceived=true